### PR TITLE
Change add-access-token-to-request dispatch to be case-insensitive.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "clj-http and ring middlewares for OAuth 2.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.3.1"]
-                 [clj-http "0.9.2"]
+                 [clj-http "0.1.2"]
                  [uri "1.1.0"]
                  [commons-codec/commons-codec "1.9"]]
   :profiles {:dev {:source-paths ["dev"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.osbert/clj-oauth2 "0.1.4"
+(defproject org.clojars.osbert/clj-oauth2 "0.1.6"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.osbert/clj-oauth2 "0.1.6"
+(defproject org.clojars.osbert/clj-oauth2 "0.1.7"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.osbert/clj-oauth2 "0.1.7"
+(defproject org.clojars.osbert/clj-oauth2 "0.1.8"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject steelval/clj-oauth2 "0.1.0"
+(defproject org.clojars.osbert/clj-oauth2 "0.1.4"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject org.clojars.osbert/clj-oauth2 "0.1.8"
+(defproject org.clojars.osbert/clj-oauth2 "0.1.9"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.3.1"]
                  [clj-http "0.1.2"]
-                 [uri "1.1.0"]
+                 [org.clojars.osbert/uri "1.2.0"]
                  [commons-codec/commons-codec "1.9"]]
   :profiles {:dev {:source-paths ["dev"]
                    :dependencies [[midje "1.6.3"]

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -122,7 +122,9 @@
         request
         {:content-type "application/x-www-form-urlencoded"
          :throw-exceptions false
-         :body {:grant_type grant-type}}
+         :body {:grant_type grant-type}
+         :conn-timeout 10000
+         :socket-timeout 10000}
         request (prepare-access-token-request request endpoint params)
         request (add-client-authentication request endpoint)
         request (update-in request [:body] uri/form-url-encode)

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -28,7 +28,7 @@
 
   Returns a map of the request, with :uri as the URI to use for the
   request, :scope of the expected scope, and :state."
-  [{:keys [authorization-uri client-id redirect-uri scope access-type]
+  [{:keys [authorization-uri client-id redirect-uri scope access-type prompt]
     :as oauth2-map}
    & [state]]
   {:pre [(has-keys? oauth2-map [:authorization-uri :client-id])]}
@@ -39,7 +39,8 @@
                 :response_type "code")
         query (if state (assoc query :state state) query)
         query (if access-type (assoc query :access_type access-type) query)
-        query (if scope (assoc query :scope (str/join " " scope)) query)]
+        query (if scope (assoc query :scope (str/join " " scope)) query)
+        query (if prompt (assoc query :prompt (str/join " " prompt)) query)]
     {:uri (.toString (uri/make (assoc uri :query query)))
      :scope scope
      :state state}))

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -28,7 +28,7 @@
 
   Returns a map of the request, with :uri as the URI to use for the
   request, :scope of the expected scope, and :state."
-  [{:keys [authorization-uri client-id redirect-uri scope access-type prompt include-granted-scopes]
+  [{:keys [authorization-uri client-id redirect-uri scope access-type prompt include-granted-scopes login-hint]
     :as oauth2-map}
    & [state]]
   {:pre [(has-keys? oauth2-map [:authorization-uri :client-id])]}
@@ -41,7 +41,8 @@
         query (if access-type (assoc query :access_type access-type) query)
         query (if scope (assoc query :scope (str/join " " scope)) query)
         query (if prompt (assoc query :prompt (str/join " " prompt)) query)
-        query (if include-granted-scopes (assoc query :include_granted_scopes include-granted-scopes) query)]
+        query (if include-granted-scopes (assoc query :include_granted_scopes include-granted-scopes) query)
+        query (if login-hint (assoc query :login_hint login-hint) query)]
     {:uri (.toString (uri/make (assoc uri :query query)))
      :scope scope
      :state state}))

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -28,7 +28,7 @@
 
   Returns a map of the request, with :uri as the URI to use for the
   request, :scope of the expected scope, and :state."
-  [{:keys [authorization-uri client-id redirect-uri scope access-type prompt]
+  [{:keys [authorization-uri client-id redirect-uri scope access-type prompt include-granted-scopes]
     :as oauth2-map}
    & [state]]
   {:pre [(has-keys? oauth2-map [:authorization-uri :client-id])]}
@@ -40,7 +40,8 @@
         query (if state (assoc query :state state) query)
         query (if access-type (assoc query :access_type access-type) query)
         query (if scope (assoc query :scope (str/join " " scope)) query)
-        query (if prompt (assoc query :prompt (str/join " " prompt)) query)]
+        query (if prompt (assoc query :prompt (str/join " " prompt)) query)
+        query (if include-granted-scopes (assoc query :include_granted_scopes include-granted-scopes) query)]
     {:uri (.toString (uri/make (assoc uri :query query)))
      :scope scope
      :state state}))
@@ -103,7 +104,7 @@
       (json/parse-stream reader true))))
 
 (defn- build-access-request
-  "Given the endpoint, and params, will return the request to be sent
+  "Given the endpoint, and params, will return cthe request to be sent
   to the resource server."
   [{:keys [access-token-uri access-query-param grant-type] :as endpoint}
    params]

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -172,7 +172,9 @@
 
 (defmulti add-access-token-to-request
   (fn [req oauth2]
-    (:token-type oauth2)))
+    (-> oauth2
+        :token-type
+        str/lower-case)))
 
 (defmethod add-access-token-to-request
   :default [req oauth2]

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -171,10 +171,9 @@
                            access-token))))
 
 (defmulti add-access-token-to-request
-  (fn [req oauth2]
-    (-> oauth2
-        :token-type
-        str/lower-case)))
+  (fn [req {:keys [token-type]}]
+    (if token-type
+      (str/lower-case token-type))))
 
 (defmethod add-access-token-to-request
   :default [req oauth2]

--- a/test/clj_oauth2/client_test.clj
+++ b/test/clj_oauth2/client_test.clj
@@ -282,3 +282,22 @@
       (is (= "put" (:body (base/put "http://localhost:18080/put" req))))
       (is (= "delete" (:body (base/delete "http://localhost:18080/delete" req))))
       (is (= 200 (:status (base/head "http://localhost:18080/head" req)))))))
+
+(deftest add-access-token-to-request
+  (testing "should add access-token as header when token-type is 'bearer'"
+    (let [token {:token-type "bearer" :access-token "ABC"}
+          [req added?] (base/add-access-token-to-request {} token)]
+      (is added?)
+      (is (= req {:headers {"Authorization" "Bearer ABC"}}))))
+
+  (testing "should add access-token as header when token-type is 'Bearer'"
+    (let [token {:token-type "Bearer" :access-token "ABC"}
+          [req added?] (base/add-access-token-to-request {} token)]
+      (is added?)
+      (is (= req {:headers {"Authorization" "Bearer ABC"}}))))
+
+  (testing "should add access-token as query-param if specified"
+    (let [token {:token-type "Bearer" :access-token "ABC" :query-param "access_token"}
+          [req added?] (base/add-access-token-to-request {} token)]
+      (is added?)
+      (is (= req {:query-params {"access_token" "ABC"}})))))


### PR DESCRIPTION
I believe that we should not do a strict dispatch based on token-type.  According to RFC6749 Section 4.2.2, the value returned from the authorization server should be considered case-insensitive, taken from https://tools.ietf.org/html/rfc6749#section-4.2.2

```
   token_type
         REQUIRED.  The type of the token issued as described in
         Section 7.1.  Value is case insensitive.
```

And from a more practical perspective, Google appears to be returning token-type "Bearer" which causes the unknown token type exception to be thrown when attempting to use clj-oauth2.client/get. This fixed the issue for me.
